### PR TITLE
Support for DPS310 sensors (https://learn.adafruit.com/adafruit-dps31…

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,12 @@ Then, run `/data/dbus-i2c/setup`.
 Temperature service, including humidity and pressure.
 Use with DVCC Shared Temperature Sense (STS) for battery temperature compensation.
 
+#### DPS310
+
+Temperature service, including pressure.
+Use with DVCC Shared Temperature Sense (STS) for battery temperature compensation.
+Adaptable to other DPS devices, but not tested with anything else than a DPS310
+
 #### SHT3x
 
 Temperature service, including humidity.

--- a/dps310_service.py
+++ b/dps310_service.py
@@ -1,0 +1,40 @@
+from smbus2 import SMBus
+import DPS
+from service_utils import SimpleI2CService
+
+dps310=DPS.DPS()
+
+def _safe_min(newValue, currentValue):
+    return min(newValue, currentValue) if currentValue else newValue
+
+
+def _safe_max(newValue, currentValue):
+    return max(newValue, currentValue) if currentValue else newValue
+
+
+class DPS310Service(SimpleI2CService):
+    def __init__(self, conn, i2cBus, i2cAddr):
+        super().__init__(conn, i2cBus, i2cAddr, 'temperature', 'BME280')
+
+    def _configure_service(self):
+#        with SMBus(self.i2cBus) as bus:
+#            self.calibrationParams = bme280.load_calibration_params(bus, self.i2cAddr)
+        self.service.add_path("/Temperature", None)
+        # default type is battery
+        self.add_settable_path("/TemperatureType", 0, 0, 2)
+        self.service.add_path("/Pressure", None)
+        self.service.add_path("/History/MinimumTemperature", None)
+        self.service.add_path("/History/MaximumTemperature", None)
+
+    def update(self):
+        with SMBus(self.i2cBus) as bus:
+            scaled_p = dps310.calcScaledPressure()
+            scaled_t = dps310.calcScaledTemperature()
+            p = dps310.calcCompPressure(scaled_p, scaled_t)
+            t = dps310.calcCompTemperature(scaled_t)    
+
+        temp = round(t, 1)
+        self.service["/Temperature"] = temp
+        self.service["/Pressure"] = round(p, 1)
+        self.service["/History/MinimumTemperature"] = _safe_min(temp, self.service["/History/MinimumTemperature"])
+        self.service["/History/MaximumTemperature"] = _safe_max(temp, self.service["/History/MaximumTemperature"])

--- a/dps310_service.py
+++ b/dps310_service.py
@@ -25,7 +25,7 @@ class DPS310Service(SimpleI2CService):
 
     def update(self):
         with SMBus(self.i2cBus) as bus:
-            dps310 = DPS(bus, self.i2cAddr)
+            dps310 = DPS.DPS(bus, self.i2cAddr)
             scaled_p = dps310.calcScaledPressure()
             scaled_t = dps310.calcScaledTemperature()
             p = dps310.calcCompPressure(scaled_p, scaled_t)

--- a/dps310_service.py
+++ b/dps310_service.py
@@ -2,7 +2,6 @@ from smbus2 import SMBus
 import DPS
 from service_utils import SimpleI2CService
 
-dps310=DPS.DPS()
 
 def _safe_min(newValue, currentValue):
     return min(newValue, currentValue) if currentValue else newValue
@@ -14,11 +13,9 @@ def _safe_max(newValue, currentValue):
 
 class DPS310Service(SimpleI2CService):
     def __init__(self, conn, i2cBus, i2cAddr):
-        super().__init__(conn, i2cBus, i2cAddr, 'temperature', 'BME280')
+        super().__init__(conn, i2cBus, i2cAddr, 'temperature', 'DPS310')
 
     def _configure_service(self):
-#        with SMBus(self.i2cBus) as bus:
-#            self.calibrationParams = bme280.load_calibration_params(bus, self.i2cAddr)
         self.service.add_path("/Temperature", None)
         # default type is battery
         self.add_settable_path("/TemperatureType", 0, 0, 2)
@@ -28,6 +25,7 @@ class DPS310Service(SimpleI2CService):
 
     def update(self):
         with SMBus(self.i2cBus) as bus:
+            dps310 = DPS(bus, self.i2cAddr)
             scaled_p = dps310.calcScaledPressure()
             scaled_t = dps310.calcScaledTemperature()
             p = dps310.calcCompPressure(scaled_p, scaled_t)

--- a/setup
+++ b/setup
@@ -184,10 +184,7 @@ if [ $scriptAction == 'INSTALL' ] ; then
 
         if [ -f "$setupOptionsDir/device-dps310-1" ]; then
 		extInstall "https://github.com/kplindegaard/smbus2" "smbus2"
-		extInstall "https://github.com/Infineon/RaspberryPi_DPS" "RaspberryPi_DPS" "master" "/"	
-                sed -e "s/import smbus/import smbus2/" -e "s/smbus\./smbus2./" < ext/DPS.py > /tmp/DPS.py
-                mv /tmp/DPS.py ext/
-
+		extInstall "https://github.com/pulquero/RaspberryPi_DPS" "RaspberryPi_DPS" "master" "/"	
 	fi
 
 	if [ -f "$setupOptionsDir/device-ina219-1" ]; then

--- a/setup
+++ b/setup
@@ -115,6 +115,19 @@ if [ $scriptAction == 'NONE' ] ; then
 				i=$((i+1))
 			done
 
+                        
+                        rm -f $setupOptionsDir/device-dps310-*
+                        i=1
+                        while true; do
+                                prompt "DPS310 (number $i): Enter I2C address or press enter to finish (e.g. 0x76/0x77): "
+                                if [ -z "$response" ]; then
+                                        break
+                                fi
+                                createDeviceFile "$setupOptionsDir/device-dps310-$i" "dps310_service" "DPS310Service" 1 $(($response)) 60000
+                                i=$((i+1))
+                        done
+
+
 			rm -f $setupOptionsDir/device-sht3x-*
 			i=1
 			while true; do
@@ -167,6 +180,14 @@ if [ $scriptAction == 'INSTALL' ] ; then
 	if [ -f "$setupOptionsDir/device-bme280-1" ]; then
 		extInstall "https://github.com/kplindegaard/smbus2" "smbus2"
 		extInstall "https://github.com/pulquero/bme280" "bme280"
+	fi
+
+        if [ -f "$setupOptionsDir/device-dps310-1" ]; then
+		extInstall "https://github.com/kplindegaard/smbus2" "smbus2"
+		extInstall "https://github.com/Infineon/RaspberryPi_DPS" "RaspberryPi_DPS" "master" "/"	
+                sed -e "s/import smbus/import smbus2/" -e "s/smbus\./smbus2./" < ext/DPS.py > /tmp/DPS.py
+                mv /tmp/DPS.py ext/
+
 	fi
 
 	if [ -f "$setupOptionsDir/device-ina219-1" ]; then


### PR DESCRIPTION
Adds support for a DPS310 device (pressure/temperature).  Very minor changes compared to the BME280.
For device support it uses the vendor DPS python library (which is patched on the fly to use smbus2)